### PR TITLE
Use the built-in fileURLToPath that works cross-platform

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -5,8 +5,9 @@ import WebSocket from 'ws';
 import fs from 'fs-extra';
 import hq from './hq.mjs';
 import path from 'path';
+import url from 'url';
 
-const HQ_ROOT = path.dirname(import.meta.url.slice('file://'.length));
+const HQ_ROOT = path.dirname(url.fileURLToPath(import.meta.url));
 
 /* eslint-disable max-statements */
 export default async (ROOT, PORT, { build, buildArg, verbose } = {}) => {


### PR DESCRIPTION
Currently `hq` does not work properly on Windows because `HQ_ROOT` is not set correctly.

```javascript
console.log(import.meta.url);
// file:///v:/hq/server.mjs
console.log(import.meta.url.slice('file://'.length));
// /v:/hq/server.mjs <== illegal for windows
console.log(path.dirname(url.fileURLToPath(import.meta.url)));
// v:\hq <== correct one
```

This pull request replaces `.slice`  with the built-in `url.fileURLToPath` that [ensures a cross-platform valid absolute path string](https://nodejs.org/api/url.html#url_url_fileurltopath_url).

