### PR TITLE
Fix import of CSS modules

### DIFF
--- a/compilers/js.mjs
+++ b/compilers/js.mjs
@@ -502,7 +502,7 @@ const compileCSSModules = async (ctx, content) => {
     ...Array.from(content.matchAll(CSS_REQUIRE_MODULES_REX)),
   ];
   const cssModules = styleImports.map(([ , filename ]) =>
-    urlToPath(querystring.unescape(url.resolve(`${querystring.escapedname(ctx.dirname)}/`, filename))));
+    urlToPath(querystring.unescape(url.resolve(`${querystring.escape(ctx.dirname)}/`, filename))));
   const extensions = styleImports.map(([ ,, ext ]) => ext);
 
   const styleBuilds = cssModules


### PR DESCRIPTION
Currently, during import of CSS module in source code HQ server throws error. The reason for that is using nonexistent method `escapedname` from Node.js core module [`querystring`](https://nodejs.org/api/querystring.html). I suppose, that expected method is [`escape`](https://nodejs.org/api/querystring.html#querystring_querystring_escape_str)